### PR TITLE
update link text on install+config page

### DIFF
--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -15,7 +15,7 @@ The Pulumi Astra provider is available as a package in all Pulumi languages:
 
 ## Setup
 
-To provision resources with the Pulumi Astra provider, you need to have Astra token. Astra maintains documentation on how to create API tokens [here](https://docs.datastax.com/en/astra/docs/manage/org/managing-org.html#_manage_application_tokens)
+To provision resources with the Pulumi Astra provider, you need to have Astra token. Astra maintains documentation on how to [create API tokens](https://docs.datastax.com/en/astra/docs/manage/org/managing-org.html#_manage_application_tokens)
 
 ## Configuration Options
 


### PR DESCRIPTION
hello!

at pulumi we try our best to avoid here, click here, and see here links and instead strive to use link text that is understandable outside of the rest of the context of the information.

thank you for considering this change!